### PR TITLE
feat: support aliased type

### DIFF
--- a/constraint.go
+++ b/constraint.go
@@ -168,6 +168,9 @@ func TypesEqual(t1, t2 Type) bool {
 	case *PointerType:
 		t2, ok := t2.(*PointerType)
 		return ok && TypesEqual(t1.Base, t2.Base)
+	case *TypeAlias:
+		t2, ok := t2.(*TypeAlias)
+		return ok && t1.Name == t2.Name && TypesEqual(t1.AliasedTo, t2.AliasedTo)
 	default:
 		return false
 	}

--- a/infer_test.go
+++ b/infer_test.go
@@ -1107,3 +1107,123 @@ func diffStrings(a, b string) string {
 	}
 	return diff.String()
 }
+
+func TestInferTypeSpec(t *testing.T) {
+    tests := []struct {
+        name     string
+        spec     *ast.TypeSpec
+        env      TypeEnv
+        wantType Type
+        wantErr  error
+    }{
+        {
+            name: "Simple type alias",
+            spec: &ast.TypeSpec{
+                Name:   &ast.Ident{Name: "MyInt"},
+                Assign: token.Pos(1), // 1 is a valid non-zero position
+                Type:   &ast.Ident{Name: "int"},
+            },
+            env: TypeEnv{"int": &TypeConstant{Name: "int"}},
+            wantType: &TypeAlias{
+                Name:      "MyInt",
+                AliasedTo: &TypeConstant{Name: "int"},
+            },
+            wantErr: nil,
+        },
+		{
+            name: "Type alias to a custom type",
+            spec: &ast.TypeSpec{
+                Name:   &ast.Ident{Name: "MyCustomType"},
+                Assign: token.Pos(1),
+                Type:   &ast.Ident{Name: "CustomType"},
+            },
+            env: TypeEnv{"CustomType": &StructType{Name: "CustomType"}},
+            wantType: &TypeAlias{
+                Name:      "MyCustomType",
+                AliasedTo: &StructType{Name: "CustomType"},
+            },
+            wantErr: nil,
+        },
+        {
+            name: "Type alias to a generic type",
+            spec: &ast.TypeSpec{
+                Name:   &ast.Ident{Name: "MyVector"},
+                Assign: token.Pos(1),
+                Type: &ast.IndexExpr{
+                    X:     &ast.Ident{Name: "Vector"},
+                    Index: &ast.Ident{Name: "int"},
+                },
+            },
+            env: TypeEnv{
+                "Vector": &GenericType{
+                    Name:       "Vector",
+                    TypeParams: []Type{&TypeVariable{Name: "T"}},
+                },
+                "int": &TypeConstant{Name: "int"},
+            },
+            wantType: &TypeAlias{
+                Name: "MyVector",
+                AliasedTo: &GenericType{
+                    Name:       "Vector",
+                    TypeParams: []Type{&TypeConstant{Name: "int"}},
+                },
+            },
+            wantErr: nil,
+        },
+        {
+            name: "Type alias to an unknown type",
+            spec: &ast.TypeSpec{
+                Name:   &ast.Ident{Name: "MyUnknown"},
+                Assign: token.Pos(1),
+                Type:   &ast.Ident{Name: "UnknownType"},
+            },
+            env: TypeEnv{},
+            wantType: nil,
+            wantErr:  fmt.Errorf("unknown identifier"),
+        },
+        {
+            name: "New interface type declaration",
+            spec: &ast.TypeSpec{
+                Name: &ast.Ident{Name: "MyInterface"},
+                Type: &ast.InterfaceType{
+                    Methods: &ast.FieldList{
+                        List: []*ast.Field{
+                            {
+                                Names: []*ast.Ident{{Name: "Method1"}},
+                                Type: &ast.FuncType{
+                                    Params:  &ast.FieldList{},
+                                    Results: &ast.FieldList{List: []*ast.Field{{Type: &ast.Ident{Name: "int"}}}},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            env: TypeEnv{"int": &TypeConstant{Name: "int"}},
+            wantType: &InterfaceType{
+                Name: "MyInterface",
+                Methods: MethodSet{
+                    "Method1": Method{
+                        Name:    "Method1",
+                        Params:  []Type{},
+                        Results: []Type{&TypeConstant{Name: "int"}},
+                    },
+                },
+            },
+            wantErr: nil,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := inferTypeSpec(tt.spec, tt.env)
+			if err != nil && err.Error() != tt.wantErr.Error() {
+				t.Errorf("InferTypeSpec() error diff:\n%s", diffStrings(err.Error(), tt.wantErr.Error()))
+				return
+			}
+            if !TypesEqual(got, tt.wantType) {
+                t.Errorf("InferTypeSpec() = %v, want %v", got, tt.wantType)
+            }
+        })
+    }
+}

--- a/type.go
+++ b/type.go
@@ -155,3 +155,13 @@ func (gt *GenericType) String() string {
 // It acts as a symbol table for type inference, mapping type variable names
 // to their inferred or declared types.
 type TypeEnv map[string]Type
+
+// TypeAlias provides a new name for an existing type.
+type TypeAlias struct {
+	Name string
+	AliasedTo Type
+}
+
+func (ta *TypeAlias) String() string {
+	return fmt.Sprintf("TypeAlias(%s = %s)", ta.Name, ta.AliasedTo.String())
+}


### PR DESCRIPTION
Inferring an aliased type name. Trace the aliased name and add it to the type environment.