### PR TITLE
feat: Support complex generic type inference

### DIFF
--- a/constraint.go
+++ b/constraint.go
@@ -29,6 +29,15 @@ func checkConstraint(t Type, constraint TypeConstraint) bool {
 			}
 		}
 	}
+	if constraint.Union {
+		// for union constraints, the type must match at least one of the constraint types
+		for _, allowedType := range constraint.Types {
+			if TypesEqual(t, allowedType) {
+				return true
+			}
+		}
+		return false
+	}
 	for _, iface := range constraint.Interfaces {
 		if !implInterface(t, iface) {
 			return false

--- a/infer_test.go
+++ b/infer_test.go
@@ -873,6 +873,195 @@ func TestInferTypeWithMultipleTypeParams(t *testing.T) {
 	}
 }
 
+func TestInferTypeWithNestedGenericTypes(t *testing.T) {
+    env := TypeEnv{
+		// Map<K, V>
+        "Map": &GenericType{
+            Name: "Map",
+            TypeParams: []Type{
+                &TypeVariable{Name: "K"},
+                &TypeVariable{Name: "V"},
+            },
+            Fields: map[string]Type{
+                "data": &MapType{
+                    KeyType:   &TypeVariable{Name: "K"},
+                    ValueType: &TypeVariable{Name: "V"},
+                },
+            },
+        },
+		// List<T>
+        "List": &GenericType{
+            Name: "List",
+            TypeParams: []Type{
+                &TypeVariable{Name: "T"},
+            },
+            Fields: map[string]Type{
+                "data": &SliceType{ElementType: &TypeVariable{Name: "T"}},
+            },
+        },
+        "string": &TypeConstant{Name: "string"},
+        "int":    &TypeConstant{Name: "int"},
+    }
+
+	// Map<string, List<int>>
+    expr := &ast.IndexListExpr{
+        X: &ast.Ident{Name: "Map"},
+        Indices: []ast.Expr{
+            &ast.Ident{Name: "string"},
+            &ast.IndexExpr{
+                X:     &ast.Ident{Name: "List"},
+                Index: &ast.Ident{Name: "int"},
+            },
+        },
+    }
+
+    result, err := InferType(expr, env)
+    if err != nil {
+        t.Fatalf("Unexpected error: %v", err)
+    }
+
+	// Map<string, List<int>>
+    expected := &GenericType{
+        Name: "Map",
+        TypeParams: []Type{
+            &TypeConstant{Name: "string"},
+            &GenericType{
+                Name:       "List",
+                TypeParams: []Type{&TypeConstant{Name: "int"}},
+                Fields: map[string]Type{
+                    "data": &SliceType{ElementType: &TypeConstant{Name: "int"}},
+                },
+            },
+        },
+        Fields: map[string]Type{
+            "data": &MapType{
+                KeyType: &TypeConstant{Name: "string"},
+                ValueType: &GenericType{
+                    Name:       "List",
+                    TypeParams: []Type{&TypeConstant{Name: "int"}},
+                    Fields: map[string]Type{
+                        "data": &SliceType{ElementType: &TypeConstant{Name: "int"}},
+                    },
+                },
+            },
+        },
+    }
+
+    if !TypesEqual(result, expected) {
+        t.Errorf("Expected %v, but got %v", expected, result)
+    }
+}
+
+func TestSubstituteTypeParams(t *testing.T) {
+    tests := []struct {
+        name       string
+        t          Type
+        fromParams []Type
+        toParams   []Type
+        expected   Type
+    }{
+        {
+            name:       "Substitute TypeVariable",
+            t:          &TypeVariable{Name: "T"},
+            fromParams: []Type{&TypeVariable{Name: "T"}},
+            toParams:   []Type{&TypeConstant{Name: "int"}},
+            expected:   &TypeConstant{Name: "int"},
+        },
+        {
+            name: "Substitute in GenericType",
+            t: &GenericType{
+                Name:       "List",
+                TypeParams: []Type{&TypeVariable{Name: "T"}},
+                Fields: map[string]Type{
+                    "data": &SliceType{ElementType: &TypeVariable{Name: "T"}},
+                },
+            },
+            fromParams: []Type{&TypeVariable{Name: "T"}},
+            toParams:   []Type{&TypeConstant{Name: "string"}},
+            expected: &GenericType{
+                Name:       "List",
+                TypeParams: []Type{&TypeConstant{Name: "string"}},
+                Fields: map[string]Type{
+                    "data": &SliceType{ElementType: &TypeConstant{Name: "string"}},
+                },
+            },
+        },
+        {
+            name: "Substitute in SliceType",
+            t:    &SliceType{ElementType: &TypeVariable{Name: "T"}},
+            fromParams: []Type{&TypeVariable{Name: "T"}},
+            toParams:   []Type{&TypeConstant{Name: "int"}},
+            expected:   &SliceType{ElementType: &TypeConstant{Name: "int"}},
+        },
+        {
+            name: "Substitute in MapType",
+            t: &MapType{
+                KeyType:   &TypeVariable{Name: "K"},
+                ValueType: &TypeVariable{Name: "V"},
+            },
+            fromParams: []Type{&TypeVariable{Name: "K"}, &TypeVariable{Name: "V"}},
+            toParams:   []Type{&TypeConstant{Name: "string"}, &TypeConstant{Name: "int"}},
+            expected: &MapType{
+                KeyType:   &TypeConstant{Name: "string"},
+                ValueType: &TypeConstant{Name: "int"},
+            },
+        },
+        {
+            name: "Substitute in FunctionType",
+            t: &FunctionType{
+                ParamTypes: []Type{&TypeVariable{Name: "T"}, &TypeVariable{Name: "U"}},
+                ReturnType: &TypeVariable{Name: "R"},
+            },
+            fromParams: []Type{&TypeVariable{Name: "T"}, &TypeVariable{Name: "U"}, &TypeVariable{Name: "R"}},
+            toParams:   []Type{&TypeConstant{Name: "int"}, &TypeConstant{Name: "string"}, &TypeConstant{Name: "bool"}},
+            expected: &FunctionType{
+                ParamTypes: []Type{&TypeConstant{Name: "int"}, &TypeConstant{Name: "string"}},
+                ReturnType: &TypeConstant{Name: "bool"},
+            },
+        },
+        {
+            name: "Substitute in nested GenericType",
+            t: &GenericType{
+                Name: "Outer",
+                TypeParams: []Type{&TypeVariable{Name: "T"}},
+                Fields: map[string]Type{
+                    "inner": &GenericType{
+                        Name:       "Inner",
+                        TypeParams: []Type{&TypeVariable{Name: "U"}},
+                        Fields: map[string]Type{
+                            "data": &TypeVariable{Name: "T"},
+                        },
+                    },
+                },
+            },
+            fromParams: []Type{&TypeVariable{Name: "T"}, &TypeVariable{Name: "U"}},
+            toParams:   []Type{&TypeConstant{Name: "int"}, &TypeConstant{Name: "string"}},
+            expected: &GenericType{
+                Name: "Outer",
+                TypeParams: []Type{&TypeConstant{Name: "int"}},
+                Fields: map[string]Type{
+                    "inner": &GenericType{
+                        Name:       "Inner",
+                        TypeParams: []Type{&TypeConstant{Name: "string"}},
+                        Fields: map[string]Type{
+                            "data": &TypeConstant{Name: "int"},
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            result := substituteTypeParams(tt.t, tt.fromParams, tt.toParams)
+            if !TypesEqual(result, tt.expected) {
+                t.Errorf("substituteTypeParams() = %v, want %v", result, tt.expected)
+            }
+        })
+    }
+}
+
 func TestCalculateStructMethodSet(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/type.go
+++ b/type.go
@@ -79,10 +79,11 @@ func (it *Interface) String() string {
 
 // InterfaceType represents an interface type with methods.
 type InterfaceType struct {
-	Name     string
-	Methods  MethodSet
-	Embedded []Type
-	IsEmpty  bool // true for interface{}
+	Name           string
+	Methods        MethodSet
+	GenericMethods map[string]GenericMethod
+	Embedded       []Type
+	IsEmpty        bool // true for interface{}
 }
 
 func (it *InterfaceType) String() string {
@@ -99,6 +100,26 @@ type Method struct {
 	IsPointer bool
 }
 
+// TODO
+func (m Method) String() string {
+	params := make([]string, len(m.Params))
+	for i, param := range m.Params {
+		params[i] = param.String()
+	}
+
+	results := make([]string, len(m.Results))
+	for i, result := range m.Results {
+		results[i] = result.String()
+	}
+
+	var pointer string
+	if m.IsPointer {
+		pointer = "*"
+	}
+
+	return fmt.Sprintf("%s%s(%s) %s", pointer, m.Name, strings.Join(params, ", "), strings.Join(results, ", "))
+}
+
 type MethodSet map[string]Method
 
 type PointerType struct {
@@ -113,9 +134,10 @@ var _ Type = (*PointerType)(nil)
 
 // StructType represents a struct type with fields and methods.
 type StructType struct {
-	Name    string
-	Fields  map[string]Type
-	Methods MethodSet
+	Name           string
+	Fields         map[string]Type
+	Methods        MethodSet
+	GenericMethods map[string]GenericMethod
 }
 
 func (st *StructType) String() string {
@@ -205,6 +227,22 @@ func (gt *GenericType) String() string {
 	return fmt.Sprintf("Generic(%s, %v)", gt.Name, params)
 }
 
+// GenericMethod represents a generic method with type parameters.
+type GenericMethod struct {
+	Name       string
+	TypeParams []Type
+	Method     Method
+}
+
+// TODO
+func (gm *GenericMethod) String() string {
+	params := make([]string, len(gm.TypeParams))
+	for i, param := range gm.TypeParams {
+		params[i] = param.String()
+	}
+	return fmt.Sprintf("GenericMethod(%s, %v)", gm.Name, params)
+}
+
 // TypeVisitor is a visitor that tracks visited types to prevent infinite recursion.
 type TypeVisitor struct {
 	visited map[string]bool
@@ -224,11 +262,6 @@ func (v *TypeVisitor) Visit(t Type) bool {
 	return false
 }
 
-// TypeEnv store and manage type variables and their types.
-// It acts as a symbol table for type inference, mapping type variable names
-// to their inferred or declared types.
-type TypeEnv map[string]Type
-
 // TypeAlias provides a new name for an existing type.
 type TypeAlias struct {
 	Name      string
@@ -238,3 +271,8 @@ type TypeAlias struct {
 func (ta *TypeAlias) String() string {
 	return fmt.Sprintf("TypeAlias(%s = %s)", ta.Name, ta.AliasedTo.String())
 }
+
+// TypeEnv store and manage type variables and their types.
+// It acts as a symbol table for type inference, mapping type variable names
+// to their inferred or declared types.
+type TypeEnv map[string]Type

--- a/type.go
+++ b/type.go
@@ -153,20 +153,40 @@ func (mt *MapType) String() string {
 type TypeConstraint struct {
 	Interfaces []Interface
 	Types      []Type
+	Union      bool // true if this is a union constraint (T1 | T2 | ...)
 }
 
 func (tc *TypeConstraint) String() string {
-	var interfaces []string
-	for _, iface := range tc.Interfaces {
-		interfaces = append(interfaces, iface.Name)
-	}
+    var separator string
+    if tc.Union {
+        separator = " | "
+    } else {
+        separator = ", "
+    }
 
-	var types []string
-	for _, t := range tc.Types {
-		types = append(types, t.String())
-	}
+    var interfaces []string
+    for _, iface := range tc.Interfaces {
+        interfaces = append(interfaces, iface.Name)
+    }
 
-	return fmt.Sprintf("Constraint([%s], [%s])", strings.Join(interfaces, ", "), strings.Join(types, ", "))
+    var types []string
+    for _, t := range tc.Types {
+        types = append(types, t.String())
+    }
+
+    interfacesStr := strings.Join(interfaces, separator)
+    typesStr := strings.Join(types, separator)
+
+    if len(interfaces) > 0 {
+        if tc.Union {
+            return fmt.Sprintf("Union([%s], [%s])", interfacesStr, typesStr)
+        }
+		return fmt.Sprintf("Constraint([%s], [%s])", interfacesStr, typesStr)
+    }
+	if tc.Union {
+		return fmt.Sprintf("Union([], [%s])", typesStr)
+	}
+	return fmt.Sprintf("Constraint([], [%s])", typesStr)
 }
 
 // GenericType represents a generic type with type parameters.

--- a/type.go
+++ b/type.go
@@ -157,32 +157,32 @@ type TypeConstraint struct {
 }
 
 func (tc *TypeConstraint) String() string {
-    var separator string
-    if tc.Union {
-        separator = " | "
-    } else {
-        separator = ", "
-    }
+	var separator string
+	if tc.Union {
+		separator = " | "
+	} else {
+		separator = ", "
+	}
 
-    var interfaces []string
-    for _, iface := range tc.Interfaces {
-        interfaces = append(interfaces, iface.Name)
-    }
+	var interfaces []string
+	for _, iface := range tc.Interfaces {
+		interfaces = append(interfaces, iface.Name)
+	}
 
-    var types []string
-    for _, t := range tc.Types {
-        types = append(types, t.String())
-    }
+	var types []string
+	for _, t := range tc.Types {
+		types = append(types, t.String())
+	}
 
-    interfacesStr := strings.Join(interfaces, separator)
-    typesStr := strings.Join(types, separator)
+	interfacesStr := strings.Join(interfaces, separator)
+	typesStr := strings.Join(types, separator)
 
-    if len(interfaces) > 0 {
-        if tc.Union {
-            return fmt.Sprintf("Union([%s], [%s])", interfacesStr, typesStr)
-        }
+	if len(interfaces) > 0 {
+		if tc.Union {
+			return fmt.Sprintf("Union([%s], [%s])", interfacesStr, typesStr)
+		}
 		return fmt.Sprintf("Constraint([%s], [%s])", interfacesStr, typesStr)
-    }
+	}
 	if tc.Union {
 		return fmt.Sprintf("Union([], [%s])", typesStr)
 	}
@@ -203,6 +203,25 @@ func (gt *GenericType) String() string {
 		params[i] = param.String()
 	}
 	return fmt.Sprintf("Generic(%s, %v)", gt.Name, params)
+}
+
+// TypeVisitor is a visitor that tracks visited types to prevent infinite recursion.
+type TypeVisitor struct {
+	visited map[string]bool
+}
+
+func NewTypeVisitor() *TypeVisitor {
+	return &TypeVisitor{visited: make(map[string]bool)}
+}
+
+// Visit marks the given type as visited and returns true if it has been visited before.
+func (v *TypeVisitor) Visit(t Type) bool {
+	key := fmt.Sprintf("%p", t)
+	if v.visited[key] {
+		return true
+	}
+	v.visited[key] = true
+	return false
 }
 
 // TypeEnv store and manage type variables and their types.

--- a/type_test.go
+++ b/type_test.go
@@ -32,6 +32,10 @@ func TestStringMethods(t *testing.T) {
 		Interfaces: []Interface{{Name: "Stringer"}},
 		Types:      []Type{&TypeConstant{Name: "int"}},
 	}
+	union := &TypeConstraint{
+		Types: []Type{&TypeConstant{Name: "int"}, &TypeConstant{Name: "string"}},
+		Union: true,
+	}
 	gt := &GenericType{
 		Name:       "Stack",
 		TypeParams: []Type{&TypeVariable{Name: "T"}},
@@ -59,6 +63,7 @@ func TestStringMethods(t *testing.T) {
 		{at, "Arr[10]TypeVar(T)"},
 		{mt, "Map[TypeConst(string)]TypeConst(int)"},
 		{tcst, "Constraint([Stringer], [TypeConst(int)])"},
+		{union, "Union([], [TypeConst(int) | TypeConst(string)])"},
 		{gt, "Generic(Stack, [TypeVar(T)])"},
 		{ta, "TypeAlias(RuneReader = InterfaceType(io.RuneReader))"},
 	}

--- a/unification.go
+++ b/unification.go
@@ -84,6 +84,7 @@ func Unify(t1, t2 Type, env TypeEnv) error {
 		if t2Slice, ok := t2.(*SliceType); ok {
 			return Unify(t1.ElementType, t2Slice.ElementType, env)
 		}
+		return ErrTypeMismatch
 	case *GenericType:
 		t2Generic, ok := t2.(*GenericType)
 		if !ok || t1.Name != t2Generic.Name || len(t1.TypeParams) != len(t2Generic.TypeParams) {


### PR DESCRIPTION
# Description

To comapatible with Go's type system, this PR introduces handling complex usage of generic and inference them.

1. Multi generic types

Example:

```go
type Pair[T, U any] struct {
    First  T
    Second U
}
```

2. Nested generic type

Example:

```go
type NestedMap[K comparable, V any] map[K][]V
```

3. Fully support generic constriants. now can use union.

Example

```go
type Number interface {
    int | float64
}

func Sum[T Number](values []T) T {
    // ...
}
```

4. Recursive Generic Type

```go
type Node[T any] struct {
    Value    T
    Children []Node[T]
}
```

5. Fix Generic Method handler
6. increase test coverage